### PR TITLE
Confidence Rater & Reset Button

### DIFF
--- a/src/common/components/CaptionBlock/CaptionBlock.js
+++ b/src/common/components/CaptionBlock/CaptionBlock.js
@@ -1,13 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import { Heading, CaptionField } from '../../components'
+import { Heading, CaptionField, ConfidenceRater } from '../../components'
 
 export const CaptionBlock = ({ title, caption, score }) => {
   return (
     <div>
       { title && <Heading level={2}>{ title }</Heading> }
-      <p>Confidence: { score }</p>
+      <ConfidenceRater score={score} />
       <CaptionField caption={caption} />
     </div>
   )

--- a/src/common/components/ConfidenceRater/ConfidenceRater.js
+++ b/src/common/components/ConfidenceRater/ConfidenceRater.js
@@ -27,7 +27,7 @@ export const ConfidenceRater = ({ score }) => {
             <span className={styles.confidenceRater__emojis}
               role='img' 
               aria-label='Awesomeee. High confidence for caption accuracy.'>🤩💯 </span>
-            one hundo p! Definitely use this caption!</span>}
+            definitely use this caption!</span>}
         </p>
       </div>
     </>

--- a/src/common/components/ConfidenceRater/ConfidenceRater.js
+++ b/src/common/components/ConfidenceRater/ConfidenceRater.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import styles from './ConfidenceRater.module.scss'
+
+export const ConfidenceRater = ({ score }) => {
+  return (
+    <>
+      <div>
+        <p>{score && 'Confidence Score: '}
+          {score <= 0.25 && <span>
+            <span className={styles.confidenceRater__emojis}
+              role='img' 
+              aria-label='Less than 25% confidence for caption accuracy. Represented by a sad face emoji and thumbsdown emoji.'>😣👎 </span> 
+            Less than 25%</span> }
+          {score > 0.25 && score <= 0.5 && <span>
+            <span className={styles.confidenceRater__emojis}
+              role='img' 
+              aria-label='Shrug emoji. About 50% confidence for caption accuracy.'>🤷‍♀️ </span>
+            feeling 50/50.</span> }
+          {score > 0.5 && score <= 0.75 && <span>
+            <span className={styles.confidenceRater__emojis}
+              role='img' 
+              aria-label='Thumbs up. About 75% confidence for caption accuracy.'>👍 </span>
+            pretty confident about this.</span> }
+          {score > 0.75 && <span>
+            <span className={styles.confidenceRater__emojis}
+              role='img' 
+              aria-label='Awesomeee. High confidence for caption accuracy.'>🤩💯 </span>
+            one hundo p! Definitely use this caption!</span>}
+        </p>
+      </div>
+    </>
+  )
+}
+
+
+ConfidenceRater.propTypes = {
+  score: PropTypes.number
+}

--- a/src/common/components/ConfidenceRater/ConfidenceRater.module.scss
+++ b/src/common/components/ConfidenceRater/ConfidenceRater.module.scss
@@ -1,0 +1,7 @@
+.confidenceRater {
+  &__emojis {
+    font-size: 30px;
+    display: inline-block;
+    margin-right: 10px;
+  }
+}

--- a/src/common/components/ConfidenceRater/index.js
+++ b/src/common/components/ConfidenceRater/index.js
@@ -1,0 +1,1 @@
+export * from './ConfidenceRater'

--- a/src/common/components/ImageUploader/ImageUploader.js
+++ b/src/common/components/ImageUploader/ImageUploader.js
@@ -49,6 +49,9 @@ class ImageUploader extends Component {
 
   handleImageChange = e => {
     e.preventDefault()
+    const {
+      hasImage
+    } = this.props
     let reader = new FileReader()
     let rawFile = e.target.files[0]
 
@@ -60,12 +63,18 @@ class ImageUploader extends Component {
         fileSize: `${this.convertBytes(rawFile.size)}`,
         rawFileSize: rawFile.size
       })
+
+      hasImage(true)
     }
 
     reader.readAsDataURL(rawFile)
   }
 
   handleReset = () => {
+    const {
+      reset,
+      hasImage
+    } = this.props
     const form = document.getElementById('imageForm')
     form.reset()
 
@@ -76,6 +85,10 @@ class ImageUploader extends Component {
       fileSize: '',
       rawFileSize: 0,
     })
+
+    // this needs to trigger a callback that clears state in the App
+    reset()
+    hasImage(false)
   }
 
   convertBytes = (bytes) => {

--- a/src/common/components/ImageUploader/ImageUploader.js
+++ b/src/common/components/ImageUploader/ImageUploader.js
@@ -15,18 +15,24 @@ class ImageUploader extends Component {
     uploadLabel: 'Upload an image!',
     imagePreviewURL: '',
     rawFile: '',
-    hasImage: false
+    hasImage: false,
+    fileSize: '',
+    rawFileSize: 0,
+    sizeLimit: 4000000,
+    errorMsg: 'Exceeds file size. Choose a smaller image 🙏~'
   }
 
   postImageToApi = () => {
     Apikey.apiKey = REACT_APP_API_KEY
     const api = new cloudmersiveImageApiClient.RecognizeApi()
     const { rawFile } = this.state
-    const { getResponse } = this.props
+    const {
+      getResponse
+    } = this.props
 
     const callback = function (error, data, res) {
       if (error) {
-        console.error(error, res)
+        console.error(error, res.text)
       } else {
         console.log('API called successfully.')
         getResponse(res.body)
@@ -50,18 +56,47 @@ class ImageUploader extends Component {
       this.setState({
         rawFile,
         imagePreviewURL: reader.result,
-        hasImage: true
+        hasImage: true,
+        fileSize: `${this.convertBytes(rawFile.size)}`,
+        rawFileSize: rawFile.size
       })
     }
 
     reader.readAsDataURL(rawFile)
   }
 
+  handleReset = () => {
+    const form = document.getElementById('imageForm')
+    form.reset()
+
+    this.setState({
+      imagePreviewURL: '',
+      rawFile: '',
+      hasImage: false,
+      fileSize: '',
+      rawFileSize: 0,
+    })
+  }
+
+  convertBytes = (bytes) => {
+    // taken from https://stackoverflow.com/questions/15900485/correct-way-to-convert-size-in-bytes-to-kb-mb-gb-in-javascript
+
+    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB']
+    if (bytes === 0) return '0 Byte'
+
+    const i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)))
+    return Math.round(bytes / Math.pow(1024, i), 2) + ' ' + sizes[i]
+  }
+
   render() {
     let {
       imagePreviewURL,
       uploadLabel,
-      hasImage
+      hasImage,
+      fileSize,
+      rawFileSize,
+      sizeLimit,
+      errorMsg
     } = this.state
     let $imagePreview
 
@@ -76,19 +111,26 @@ class ImageUploader extends Component {
 
     return (
       <>
-        <form onSubmit={this.handleSubmit}>
-          {!hasImage && <label htmlFor='imageFile' className={'button'}>{uploadLabel}</label>}
-          <input type='file'
-            id='imageFile'
-            name='imageFile'
-            accept='image/png, image/jpeg'
-            onChange={this.handleImageChange}
-            className={'visually-hidden'}
-          />
+        <div className={styles.imageUploader__container}>
+          <form id='imageForm' onSubmit={this.handleSubmit}>
+            {!hasImage && <label htmlFor='imageFile' className={'button'}>{uploadLabel}</label>}
+            <input type='file'
+              id='imageFile'
+              name='imageFile'
+              accept='image/png, image/jpeg'
+              onChange={this.handleImageChange}
+              className={'visually-hidden'}
+            />
 
+            {hasImage && rawFileSize <= sizeLimit && <Button type={'submit'}>Generate Caption!</Button>}
 
-          {hasImage && <Button type={'submit'}>Generate Caption!</Button>}
-        </form>
+            {rawFileSize > sizeLimit && <span className={styles.imageUploader__fileSize}>{fileSize}</span>}
+          </form>
+
+          {hasImage && <Button className={styles.imageUploader__reset} onClick={this.handleReset}>Reset!</Button>}
+        </div>
+
+        {rawFileSize > sizeLimit && <span className={styles.imageUploader__errorMsg}>{errorMsg}</span>}
 
         { $imagePreview }
       </>

--- a/src/common/components/ImageUploader/ImageUploader.module.scss
+++ b/src/common/components/ImageUploader/ImageUploader.module.scss
@@ -1,4 +1,33 @@
-.imageUploader {}
+@import '../../styles/variables.scss';
+
+.imageUploader {
+  &__container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  &__fileSize {
+    font-family: $sansSerif;
+    font-size: 28px;
+    margin: 0 15px;
+    letter-spacing: -2px;
+  }
+
+  &__errorMsg {
+    display: inline-block;
+    padding: 5px 15px;
+    margin: 10px 0;
+    background: $red;
+    color: #FFF;
+    font-weight: 700;
+    border-radius: 5px;
+  }
+
+  &__reset {
+    margin: 5px 5px 15px;
+  }
+}
 
 .imageContainer {
   max-width: 1000px;

--- a/src/common/components/index.js
+++ b/src/common/components/index.js
@@ -1,6 +1,7 @@
 export * from './Button'
 export * from './CaptionBlock'
 export * from './CaptionField'
+export * from './ConfidenceRater'
 export * from './Heading'
 export * from './ImageUploader'
 export * from './Tooltip'

--- a/src/common/styles/variables.scss
+++ b/src/common/styles/variables.scss
@@ -5,6 +5,7 @@ $lavender: #bdadea;
 $darkpurple: rgba(darken($lavender, 15%), 0.25);
 $green: #40f99b;
 $darkgreen: rgba(64,249,155, 0.25);
+$red: firebrick;
 
 /* FONTS */
 $sansSerif: 'Ubuntu', sans-serif;

--- a/src/core/App.js
+++ b/src/core/App.js
@@ -18,6 +18,7 @@ class App extends Component {
   state = {
     title: 'Generate',
     subtitle: 'Alt Text!',
+    hasImage: false,
     firstCaption: {},
     secondCaption: {}
   }
@@ -29,18 +30,31 @@ class App extends Component {
     })
   }
 
+  resetState = () => {
+    this.setState({
+      firstCaption: {},
+      secondCaption: {}
+    })
+  }
+
+  hasImage = (bool) => {
+    this.setState({ hasImage: bool })
+  }
+
   render() {
     const {
       firstCaption,
       secondCaption,
       title,
-      subtitle
+      subtitle,
+      hasImage
     } = this.state
 
     return (
       <main className={styles.App}>
         <header>
-          <Heading level={1}>{title} <span>{subtitle}</span></Heading>
+          <Heading level={1} className={styles.App__title}>{title} <span className={styles.App__subtitle}>{subtitle}</span></Heading>
+          {!hasImage && <p className={styles.App__description}>Having writers block? Can't seem to come up with alt text for your image? Let 'Generate Alt Text!' do the work for you! This generator uses Cloudmersive's Image Descriptions and Captioning API, to generate a one sentence caption for any uploaded image.</p>}
         </header>
 
         <div className={styles['App-grid']}>
@@ -56,7 +70,9 @@ class App extends Component {
           </div>
 
           <div className={styles['App-column']}>
-            <ImageUploader getResponse={this.getResponse} />
+            <ImageUploader hasImage={this.hasImage}
+              getResponse={this.getResponse} 
+              reset={this.resetState} />
           </div>
         </div>
 

--- a/src/core/App.module.scss
+++ b/src/core/App.module.scss
@@ -35,14 +35,22 @@
     }
   }
 
-  h1 {
+  &__title {
     margin: 0;
+  }
 
-    span {
-      display: block;
-      margin-top: -10px;
-      font-size: 34px;
-    }
+  &__subtitle {
+    display: block;
+    margin-top: -10px;
+    font-size: 34px;
+  }
+
+  &__description {
+    max-width: 1300px;
+    text-align: center;
+    margin: 20px auto;
+    width: 650px;
+    font-size: 18px;
   }
 
   header {


### PR DESCRIPTION
## What has changed
Created confidence rater component, to display the API's confidence value into an emoji representation. Also created a button + methods to handle resetting the form & app back to the start state.

## Changelog
`src/common/components/CaptionBlock/CaptionBlock.js`: import confidence rater
`src/common/components/ConfidenceRater/ConfidenceRater.js`: confidence rater component
`src/common/components/ConfidenceRater/ConfidenceRater.module.scss`: rater styles
`src/common/components/ImageUploader/ImageUploader.js`: handle too large file sizes and form reset
`src/common/components/ImageUploader/ImageUploader.module.scss`: uploader component styles
`src/core/App.js`: app reset
`src/core/App.module.scss`: app styles and classnames


## Visuals
|Starting state|When image is too large for API|When image is uploaded|When caption is generated|
|--|--|--|--|
|<img width="1552" alt="Screen Shot 2020-02-18 at 5 31 30 PM" src="https://user-images.githubusercontent.com/16946288/74784081-21cdad00-5275-11ea-8e61-3ba7b8a5cb05.png">|<img width="1552" alt="Screen Shot 2020-02-18 at 5 35 49 PM" src="https://user-images.githubusercontent.com/16946288/74784086-25f9ca80-5275-11ea-80ef-4692532b3305.png">|<img width="1552" alt="Screen Shot 2020-02-18 at 5 31 40 PM" src="https://user-images.githubusercontent.com/16946288/74784097-2abe7e80-5275-11ea-9ac9-99bdf2657a19.png">|<img width="1552" alt="Screen Shot 2020-02-18 at 5 26 25 PM" src="https://user-images.githubusercontent.com/16946288/74784106-327e2300-5275-11ea-9172-1915bbfd54c4.png">|

|Confidence Rater, lower than 25%|25-50%|50-75%|75-100% confidence|
|--|--|--|--|
|<img width="353" alt="Screen Shot 2020-02-18 at 5 30 00 PM" src="https://user-images.githubusercontent.com/16946288/74784145-4aee3d80-5275-11ea-86a3-4043b3f4906a.png">|<img width="378" alt="Screen Shot 2020-02-18 at 5 30 21 PM" src="https://user-images.githubusercontent.com/16946288/74784151-4e81c480-5275-11ea-964c-36f55ced8ee7.png">|<img width="425" alt="Screen Shot 2020-02-18 at 5 30 49 PM" src="https://user-images.githubusercontent.com/16946288/74784163-52154b80-5275-11ea-9b08-2b35d28e5cd5.png">|<img width="454" alt="Screen Shot 2020-02-18 at 5 31 20 PM" src="https://user-images.githubusercontent.com/16946288/74784169-55103c00-5275-11ea-8383-c2862b156e4b.png">|

