### PR TITLE
Tooltip animation and Responsive Styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3315,6 +3315,11 @@
         }
       }
     },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+    },
     "clean-css": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "classnames": "^2.2.6",
     "cloudmersive-image-api-client": "^1.3.1",
     "node-sass": "^4.13.1",
     "react": "^16.12.0",

--- a/src/common/components/CaptionField/CaptionField.js
+++ b/src/common/components/CaptionField/CaptionField.js
@@ -17,6 +17,7 @@ export const CaptionField = ({ id, caption }) => {
     textAreaRef.current.select()
     document.execCommand('copy')
     e.target.focus()
+    console.log(e.target)
     setCopySuccess('Copied!')
   }
 

--- a/src/common/components/CaptionField/CaptionField.js
+++ b/src/common/components/CaptionField/CaptionField.js
@@ -17,8 +17,11 @@ export const CaptionField = ({ id, caption }) => {
     textAreaRef.current.select()
     document.execCommand('copy')
     e.target.focus()
-    console.log(e.target)
     setCopySuccess('Copied!')
+
+    setTimeout(() => {
+      setCopySuccess('')
+    }, 1000)
   }
 
   return (
@@ -36,7 +39,7 @@ export const CaptionField = ({ id, caption }) => {
 
       { document.queryCommandSupported('copy') && <div>
         <Button onClick={copyToClipboard} disabled={!hasCaption(caption)}>Copy to clipboard</Button>
-        { copySuccess && <Tooltip>{copySuccess}</Tooltip> }
+        <Tooltip className={copySuccess ? 'fadein' : 'fadeout'}>Copied!</Tooltip>
       </div> }
     </>
   )

--- a/src/common/components/ImageUploader/ImageUploader.module.scss
+++ b/src/common/components/ImageUploader/ImageUploader.module.scss
@@ -39,4 +39,8 @@
     height: 100%;
     object-fit: contain;
   }
+
+  @media screen and (max-width: 750px) {
+    height: auto;
+  }
 }

--- a/src/common/components/Tooltip/Tooltip.js
+++ b/src/common/components/Tooltip/Tooltip.js
@@ -1,13 +1,18 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import classNames from 'classnames'
 
 import styles from './Tooltip.module.scss'
 
-export const Tooltip = ({ children }) => (
-  <div className={styles.tooltip}>
-    <span className={styles['tooltip-text']}>{children}</span>
-  </div>
-)
+export const Tooltip = ({ children, ...rest }) => {
+  const tooltipClassName = classNames(styles.tooltip, rest.className)
+
+  return (
+    <div className={tooltipClassName}>
+      <span className={styles['tooltip-text']}>{children}</span>
+    </div>
+  )
+}
 
 Tooltip.propTypes = {
   children: PropTypes.string.isRequired

--- a/src/common/components/Tooltip/Tooltip.module.scss
+++ b/src/common/components/Tooltip/Tooltip.module.scss
@@ -13,6 +13,6 @@
     content: '✔';
     display: inline-block;
     margin-right: 5px;
-    color: $darkgreen;
+    color: darkslategrey;
   }
 }

--- a/src/common/components/Tooltip/Tooltip.module.scss
+++ b/src/common/components/Tooltip/Tooltip.module.scss
@@ -5,40 +5,40 @@
   display: inline-block;
   border-bottom: 1px dotted black; /* If you want dots under the hoverable text */
 
-  &-text {
-    visibility: hidden;
-    width: 120px;
-    background-color: $grey;
-    color: white;
-    text-align: center;
-    padding: 5px 0;
-    border-radius: 6px;
+  // &-text {
+  //   visibility: hidden;
+  //   width: 120px;
+  //   background-color: $grey;
+  //   color: white;
+  //   text-align: center;
+  //   padding: 5px 0;
+  //   border-radius: 6px;
 
-    /* Position the tooltip text */
-    position: absolute;
-    z-index: 1;
-    bottom: 125%;
-    left: 50%;
-    margin-left: -60px;
+  //   /* Position the tooltip text */
+  //   position: absolute;
+  //   z-index: 1;
+  //   bottom: 125%;
+  //   left: 50%;
+  //   margin-left: -60px;
 
-    /* Fade in tooltip */
-    opacity: 0;
-    transition: opacity 0.3s;
+  //   /* Fade in tooltip */
+  //   opacity: 0;
+  //   transition: opacity 0.3s;
 
-    &:after {
-      content: "";
-      position: absolute;
-      top: 100%;
-      left: 50%;
-      margin-left: -5px;
-      border-width: 5px;
-      border-style: solid;
-      border-color: $grey transparent transparent transparent;
-    }
+  //   &:after {
+  //     content: "";
+  //     position: absolute;
+  //     top: 100%;
+  //     left: 50%;
+  //     margin-left: -5px;
+  //     border-width: 5px;
+  //     border-style: solid;
+  //     border-color: $grey transparent transparent transparent;
+  //   }
 
-    &.copied {
-      visibility: visible;
-      opacity: 1;
-    }
-  }
+  //   &.copied {
+  //     visibility: visible;
+  //     opacity: 1;
+  //   }
+  // }
 }

--- a/src/common/components/Tooltip/Tooltip.module.scss
+++ b/src/common/components/Tooltip/Tooltip.module.scss
@@ -3,42 +3,16 @@
 .tooltip {
   position: relative;
   display: inline-block;
-  border-bottom: 1px dotted black; /* If you want dots under the hoverable text */
+  margin: 0 15px;
+  font-family: $sansSerif;
+  text-transform: uppercase;
+  letter-spacing: -0.5px;
+  transition: opacity 300ms ease-in-out;
 
-  // &-text {
-  //   visibility: hidden;
-  //   width: 120px;
-  //   background-color: $grey;
-  //   color: white;
-  //   text-align: center;
-  //   padding: 5px 0;
-  //   border-radius: 6px;
-
-  //   /* Position the tooltip text */
-  //   position: absolute;
-  //   z-index: 1;
-  //   bottom: 125%;
-  //   left: 50%;
-  //   margin-left: -60px;
-
-  //   /* Fade in tooltip */
-  //   opacity: 0;
-  //   transition: opacity 0.3s;
-
-  //   &:after {
-  //     content: "";
-  //     position: absolute;
-  //     top: 100%;
-  //     left: 50%;
-  //     margin-left: -5px;
-  //     border-width: 5px;
-  //     border-style: solid;
-  //     border-color: $grey transparent transparent transparent;
-  //   }
-
-  //   &.copied {
-  //     visibility: visible;
-  //     opacity: 1;
-  //   }
-  // }
+  &:before {
+    content: '✔';
+    display: inline-block;
+    margin-right: 5px;
+    color: $darkgreen;
+  }
 }

--- a/src/common/styles/index.scss
+++ b/src/common/styles/index.scss
@@ -96,3 +96,11 @@ button, .button {
     margin-left: 10px;
   }
 }
+
+.fadein {
+  opacity: 1;
+}
+
+.fadeout {
+  opacity: 0;
+}

--- a/src/core/App.module.scss
+++ b/src/core/App.module.scss
@@ -22,9 +22,14 @@
 
   &-grid {
     max-width: 1300px;
+    padding: 0 40px;
     margin: 0 auto;
     display: flex;
     justify-content: space-between;
+
+    @media screen and (max-width: 750px) {
+      flex-direction: column-reverse;
+    }
   }
 
   &-column {
@@ -32,6 +37,10 @@
 
     &:first-child {
       text-align: left;
+
+      @media screen and (max-width: 750px) {
+        margin: 50px 0 20px;
+      }
     }
   }
 
@@ -49,15 +58,22 @@
     max-width: 1300px;
     text-align: center;
     margin: 20px auto;
-    width: 650px;
+    width: 55%;
     font-size: 18px;
+
+    @media screen and (max-width: 750px) {
+      margin: 20px 0;
+      width: 100%;
+    }
   }
 
   header {
     margin: 30px 0;
+    padding: 0 40px;
   }
 
   footer {
     margin-top: 30px;
+    padding: 0 40px;
   }
 }


### PR DESCRIPTION
## What has changed and why
This PR includes the fade in and fade out of the "copied!" tooltip. As well as responsive styles for tablet and mobile devices.

## Changelog 
`package.json`: added classnames to deal with state trigger classnames for tooltip component
`src/common/components/CaptionField/CaptionField.js`: changed logic for tooltip appearing
`src/common/components/Tooltip/Tooltip.js`: refactor tooltip component
`src/common/components/Tooltip/Tooltip.module.scss`: tooltip styles
`src/common/styles/index.scss`: fade classes

### Responsive styles
`src/common/components/ImageUploader/ImageUploader.module.scss`
`src/core/App.module.scss`


## Visuals 👀
|caption before being copied|copied tooltip visible|
|--|--|
|<img width="374" alt="Screen Shot 2020-02-19 at 2 15 17 PM" src="https://user-images.githubusercontent.com/16946288/74868403-32892c00-5324-11ea-89b4-8dbc5a0f23be.png">|<img width="370" alt="Screen Shot 2020-02-19 at 2 15 06 PM" src="https://user-images.githubusercontent.com/16946288/74868413-36b54980-5324-11ea-8b91-bc5e3ad1d2f1.png">|

|Tablet landscape|Tablet portrait|
|--|--|
|<img width="647" alt="Screen Shot 2020-02-19 at 2 17 22 PM" src="https://user-images.githubusercontent.com/16946288/74868442-446acf00-5324-11ea-82ba-ee5cb7eb4d6d.png">|<img width="456" alt="Screen Shot 2020-02-19 at 2 17 29 PM" src="https://user-images.githubusercontent.com/16946288/74868452-47fe5600-5324-11ea-872e-a3e147a55bae.png">|

|Mobile before caption|Mobile after caption|
|--|--|
|<img width="248" alt="Screen Shot 2020-02-19 at 2 24 57 PM" src="https://user-images.githubusercontent.com/16946288/74868474-52b8eb00-5324-11ea-9ddb-39bd858b172f.png">|<img width="265" alt="Screen Shot 2020-02-19 at 2 25 11 PM" src="https://user-images.githubusercontent.com/16946288/74868486-56e50880-5324-11ea-89e6-9dc1f051afad.png">|

