### PR TITLE
Footer Links & Accessibility styles

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <script src="https://kit.fontawesome.com/775e53fd60.js" crossorigin="anonymous"></script>
     <title>Generate Alt Text!</title>
   </head>
   <body>

--- a/src/common/components/Button/Button.js
+++ b/src/common/components/Button/Button.js
@@ -6,5 +6,5 @@ export const Button = ({ children, ...rest }) => (
 )
 
 Button.propTypes = {
-  children: PropTypes.string.isRequired
+  children: PropTypes.node.isRequired
 }

--- a/src/common/components/ConfidenceRater/ConfidenceRater.js
+++ b/src/common/components/ConfidenceRater/ConfidenceRater.js
@@ -7,7 +7,7 @@ export const ConfidenceRater = ({ score }) => {
   return (
     <>
       <div>
-        <p>{score && 'Confidence Score: '}
+        <p tabIndex={0}>{score && 'Confidence Score: '}
           {score <= 0.25 && <span>
             <span className={styles.confidenceRater__emojis}
               role='img' 

--- a/src/common/components/ImageUploader/ImageUploader.js
+++ b/src/common/components/ImageUploader/ImageUploader.js
@@ -19,7 +19,7 @@ class ImageUploader extends Component {
     fileSize: '',
     rawFileSize: 0,
     sizeLimit: 4000000,
-    errorMsg: 'Exceeds file size. Choose a smaller image 🙏~'
+    errorMsg: 'This image exceeds the max file size of 4MB. Please choose a smaller image 🙏~'
   }
 
   postImageToApi = () => {
@@ -126,7 +126,6 @@ class ImageUploader extends Component {
       <>
         <div className={styles.imageUploader__container}>
           <form id='imageForm' onSubmit={this.handleSubmit}>
-            {!hasImage && <label htmlFor='imageFile' className={'button'}>{uploadLabel}</label>}
             <input type='file'
               id='imageFile'
               name='imageFile'
@@ -134,16 +133,26 @@ class ImageUploader extends Component {
               onChange={this.handleImageChange}
               className={'visually-hidden'}
             />
+            {!hasImage && <label htmlFor='imageFile' className={'button'}>{uploadLabel}</label>}
 
-            {hasImage && rawFileSize <= sizeLimit && <Button type={'submit'}>Generate Caption!</Button>}
+            {hasImage && rawFileSize <= sizeLimit && <Button type={'submit'}>Generate <span className={'visually-hidden'}>your</span> Caption!</Button>}
 
-            {rawFileSize > sizeLimit && <span className={styles.imageUploader__fileSize}>{fileSize}</span>}
+            {rawFileSize > sizeLimit && <span className={styles.imageUploader__fileSize}
+              aria-label={`The file size of this image is ${fileSize}.`}
+            >{fileSize}</span>}
           </form>
 
-          {hasImage && <Button className={styles.imageUploader__reset} onClick={this.handleReset}>Reset!</Button>}
+          {hasImage && <Button className={styles.imageUploader__reset}
+            onClick={this.handleReset}
+            aria-label={'Reset the app to upload a different image.'}>
+            Reset!
+          </Button>}
         </div>
 
-        {rawFileSize > sizeLimit && <span className={styles.imageUploader__errorMsg}>{errorMsg}</span>}
+        {rawFileSize > sizeLimit && <span role={'alert'}
+          className={styles.imageUploader__errorMsg}
+          aria-live={'assertive'}
+        >{errorMsg}</span>}
 
         { $imagePreview }
       </>

--- a/src/common/components/Tooltip/Tooltip.js
+++ b/src/common/components/Tooltip/Tooltip.js
@@ -9,7 +9,11 @@ export const Tooltip = ({ children, ...rest }) => {
 
   return (
     <div className={tooltipClassName}>
-      <span className={styles['tooltip-text']}>{children}</span>
+      <span role={'alert'}
+        className={styles['tooltip-text']}
+        aria-live={'assertive'}
+        aria-label={'The generated caption has been copied to your clipboard.'}
+      >{children}</span>
     </div>
   )
 }

--- a/src/common/styles/index.scss
+++ b/src/common/styles/index.scss
@@ -51,6 +51,10 @@ a {
     text-decoration: none;
   }
 
+  &:focus {
+    outline: auto $lavender 4px;
+  }
+
   &:visited {
     color: inherit;
   }
@@ -77,11 +81,19 @@ button, .button {
   white-space: nowrap;
   @include box-shadow($darkpurple);
 
-  &:hover,
+  &:hover:not([disabled]),
   &:focus {
     @include hover-box-shadow($darkpurple);
     -webkit-transform: translateY(-2px);
     transform: translateY(-2px);
+  }
+
+  &[disabled]:hover {
+    cursor: not-allowed;
+  }
+
+  &:focus {
+    outline: dotted $lavender 4px;
   }
 
   &:active {
@@ -95,6 +107,20 @@ button, .button {
   & ~ .button {
     margin-left: 10px;
   }
+}
+
+p,
+textarea {
+  &:focus {
+    outline: $lavender auto 5px;
+  }
+}
+
+input[type=file]:focus + label.button {
+  @include hover-box-shadow($darkpurple);
+  -webkit-transform: translateY(-2px);
+  transform: translateY(-2px);
+  outline: dotted $lavender 4px;
 }
 
 .fadein {

--- a/src/common/styles/index.scss
+++ b/src/common/styles/index.scss
@@ -55,7 +55,7 @@ a {
     outline: auto $lavender 4px;
   }
 
-  &:visited {
+  &, &:visited, &:active {
     color: inherit;
   }
 }

--- a/src/core/App.js
+++ b/src/core/App.js
@@ -59,6 +59,12 @@ class App extends Component {
 
         <div className={styles['App-grid']}>
           <div className={styles['App-column']}>
+            <ImageUploader hasImage={this.hasImage}
+              getResponse={this.getResponse} 
+              reset={this.resetState} />
+          </div>
+
+          <div className={styles['App-column']}>
             <CaptionBlock title={'First Caption'}
               caption={firstCaption.Description}
               score={firstCaption.ConfidenceScore}
@@ -67,12 +73,6 @@ class App extends Component {
               caption={secondCaption.Description}
               score={secondCaption.ConfidenceScore}
             />
-          </div>
-
-          <div className={styles['App-column']}>
-            <ImageUploader hasImage={this.hasImage}
-              getResponse={this.getResponse} 
-              reset={this.resetState} />
           </div>
         </div>
 

--- a/src/core/App.js
+++ b/src/core/App.js
@@ -52,9 +52,10 @@ class App extends Component {
 
     return (
       <main className={styles.App}>
-        <header>
+        <header className={styles.App__header}>
           <Heading level={1} className={styles.App__title}>{title} <span className={styles.App__subtitle}>{subtitle}</span></Heading>
           {!hasImage && <p className={styles.App__description}>Having writers block? Can't seem to come up with alt text for your image? Let 'Generate Alt Text!' do the work for you! This generator uses Cloudmersive's Image Descriptions and Captioning API, to generate a one sentence caption for any uploaded image.</p>}
+          <span className={styles.App__fineprint}>Powered by <a href="//api.cloudmersive.com/docs/image.asp" target="_blank" rel="noopener noreferrer">Cloudmersive's Image Processing API</a></span>
         </header>
 
         <div className={styles['App-grid']}>
@@ -76,8 +77,25 @@ class App extends Component {
           </div>
         </div>
 
-        <footer>
+        <footer className={styles.App__footer}>
           <span>&copy; { new Date().getFullYear() } <a href="//hellomkreyes.com" target="_blank" rel="noopener noreferrer">M.K. Reyes</a></span>
+          <ul className={styles.App__socialList}>
+            <li>
+              <a href="//github.com/hellomkreyes" target="_blank" rel="noopener noreferrer" aria-label="Visit my Github profile.">
+                <i className="fab fa-github-alt"></i>
+              </a>
+            </li>
+            <li>
+              <a href="//www.linkedin.com/in/mkreyes/" target="_blank" rel="noopener noreferrer" aria-label="Visit my LinkedIn profile.">
+                <i className="fab fa-linkedin-in"></i>
+              </a>
+            </li>
+            <li>
+              <a href="//codepen.io/hellomkreyes" target="_blank" rel="noopener noreferrer" aria-label="Visit my codepen!">
+                <i className="fab fa-codepen"></i>
+              </a>
+            </li>
+          </ul>
         </footer>
       </main>
     )

--- a/src/core/App.module.scss
+++ b/src/core/App.module.scss
@@ -26,16 +26,17 @@
     margin: 0 auto;
     display: flex;
     justify-content: space-between;
+    flex-direction: row-reverse;
 
     @media screen and (max-width: 750px) {
-      flex-direction: column-reverse;
+      flex-direction: column;
     }
   }
 
   &-column {
     flex: 1 1 100%;
 
-    &:first-child {
+    &:last-child {
       text-align: left;
 
       @media screen and (max-width: 750px) {

--- a/src/core/App.module.scss
+++ b/src/core/App.module.scss
@@ -23,7 +23,7 @@
   &-grid {
     max-width: 1300px;
     padding: 0 40px;
-    margin: 0 auto;
+    margin: 0 auto 40px;
     display: flex;
     justify-content: space-between;
     flex-direction: row-reverse;
@@ -68,13 +68,35 @@
     }
   }
 
-  header {
-    margin: 30px 0;
+  &__fineprint {
+    font-size: 10px;
+  }
+
+  &__header {
+    max-width: 1300px;
+    margin: 30px auto;
     padding: 0 40px;
   }
 
-  footer {
-    margin-top: 30px;
+  &__footer {
+    max-width: 1300px;
+    margin: 20px auto;
     padding: 0 40px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  &__socialList {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    justify-content: space-evenly;
+    font-size: 20px;
+
+    li:not(:last-child) {
+      margin-right: 15px;
+    }
   }
 }


### PR DESCRIPTION
## What has changed and why
This PR includes additional links in the footer as well as styles and labels for accessibility.

## Changelog
`public/index.html`: add fontawesome
`src/common/components/Button/Button.js`: change to accept node, for visually-hidden text
`src/common/components/ConfidenceRater/ConfidenceRater.js`: add tab-index for confidence rater text
`src/common/components/ImageUploader/ImageUploader.js`: labels
`src/common/components/Tooltip/Tooltip.js`: alert attributes
`src/common/styles/index.scss`: accessibility styles
`src/core/App.js`: alerts and adding footer links
`src/core/App.module.scss`: footer styles

## Visuals 👀 
|Button focus|Textarea focus|Link focus|
|--|--|--|
|<img width="225" alt="Screen Shot 2020-02-19 at 3 15 43 PM" src="https://user-images.githubusercontent.com/16946288/74874644-07580a00-532f-11ea-9b0f-248de152db4b.png">|<img width="360" alt="Screen Shot 2020-02-19 at 3 15 57 PM" src="https://user-images.githubusercontent.com/16946288/74874670-1343cc00-532f-11ea-9ade-313c16c3a186.png">|<img width="170" alt="Screen Shot 2020-02-19 at 3 16 06 PM" src="https://user-images.githubusercontent.com/16946288/74874686-1a6ada00-532f-11ea-895d-09867d9df14e.png">|

|Footer links|
|--|
|<img width="1552" alt="Screen Shot 2020-02-19 at 3 43 22 PM" src="https://user-images.githubusercontent.com/16946288/74874739-2d7daa00-532f-11ea-82d2-5592d493d9c7.png">|
